### PR TITLE
ci: add PR preview deployments

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,0 +1,41 @@
+name: PR Preview Deploy
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+
+concurrency:
+  group: preview-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  deploy-preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install mkdocs mkdocs-material mkdocs-video mkdocs-redirects
+
+      - name: Build MkDocs site
+        if: github.event.action != 'closed'
+        run: mkdocs build
+
+      - name: Deploy PR Preview
+        uses: rossjrw/pr-preview-action@v1
+        with:
+          source-dir: ./site/
+          preview-branch: gh-pages
+          umbrella-dir: pr-preview
+          action: auto


### PR DESCRIPTION
## Summary
Adds automatic preview deployments for every PR so reviewers can see changes live before merging.

## How It Works
- When a PR is opened/updated → builds MkDocs and deploys to preview
- Preview URL: `https://docs.xdc.network/pr-preview/pr-{number}/`
- When PR is closed/merged → preview is automatically cleaned up
- Posts preview link as a comment on the PR

## Example
After this is merged, PR #29 would be viewable at:
`https://docs.xdc.network/pr-preview/pr-29/`

## Why
Makes it much easier to review documentation changes visually before merging.

🔷