### PR TITLE
fix: PR preview permissions

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -1,11 +1,11 @@
 name: PR Preview Deploy
 
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, synchronize, reopened, closed]
 
 concurrency:
-  group: preview-${{ github.ref }}
+  group: preview-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
@@ -15,8 +15,10 @@ jobs:
       contents: write
       pull-requests: write
     steps:
-      - name: Checkout repository
+      - name: Checkout PR head
         uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
 
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -39,3 +41,4 @@ jobs:
           preview-branch: gh-pages
           umbrella-dir: pr-preview
           action: auto
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Fix
The PR preview workflow had permission issues posting comments.

## Changes
- Use `pull_request_target` instead of `pull_request` for proper permissions from base repo
- Add explicit token parameter
- Correctly checkout PR head SHA

## After Merge
Existing open PRs will automatically get preview deployments on next push, or you can re-run their workflows manually.

🔷