### PR TITLE
Add Envio to Data and Analytics

### DIFF
--- a/docs/smartcontract/data-analytics.md
+++ b/docs/smartcontract/data-analytics.md
@@ -21,12 +21,12 @@ The XDC Network’s data and analytics tools are critical for understanding the 
 
 # Envio
 ## Overview:
-Envio is the data layer for blockchain apps. It gives XDC developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud.
+Envio is the data layer for blockchain apps. It gives XDC developers the fastest, most flexible way to get real-time and historical on-chain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud.
 
 ## Key Features:
 
 - **Any EVM Chain Support:** Envio's HyperIndex natively supports indexing any EVM chain out of the box, including XDC, using your own RPC as the data source.
-- **Flexible Data Access:** From a single GraphQL API to raw high-speed access to onchain data.
+- **Flexible Data Access:** From a single GraphQL API to raw high-speed access to on-chain data.
 - **Managed Hosting:** Deploy and run indexers with managed hosting on Envio Cloud.
 
 ## Use Cases:

--- a/docs/smartcontract/data-analytics.md
+++ b/docs/smartcontract/data-analytics.md
@@ -19,6 +19,28 @@ The XDC Network’s data and analytics tools are critical for understanding the 
 
 ------------
 
+# Envio
+## Overview:
+Envio is the data layer for blockchain apps. It gives XDC developers the fastest, most flexible way to get real-time and historical onchain data, from a single GraphQL API to raw high-speed access, with managed hosting on Envio Cloud.
+
+## Key Features:
+
+- **Any EVM Chain Support:** Envio's HyperIndex natively supports indexing any EVM chain out of the box, including XDC, using your own RPC as the data source.
+- **Flexible Data Access:** From a single GraphQL API to raw high-speed access to onchain data.
+- **Managed Hosting:** Deploy and run indexers with managed hosting on Envio Cloud.
+
+## Use Cases:
+
+- **Application Backends:** Power dashboards, wallets, and dApps with real-time and historical XDC data.
+- **Onchain Analytics:** Query transactions, logs, and events to understand network and contract activity.
+
+**Envio links:**
+
+- [Envio](https://envio.dev/?utm_source=xdc&utm_medium=partner-docs) - the data layer for blockchain apps
+- [Envio Docs](https://docs.envio.dev/) - HyperIndex documentation
+
+------------
+
 # XDCScan - Mainnet
 ## Overview:
 [XDCScan](https://xdcscan.io/) is the official block explorer for the XDC Network, providing a user-friendly interface to explore and interact with the blockchain. It allows users to search for transactions, view block details, and explore smart contracts deployed on the network. XDCScan is a vital tool for anyone interacting with the XDC Network, from developers to casual users.


### PR DESCRIPTION
Adds Envio to the Data and Analytics page, following the existing section format.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a new “Envio” section describing Envio as a data layer for GraphQL and high-speed onchain data access.
  * Included key features, common use cases, and a curated list of Envio links for further information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->